### PR TITLE
Start and load discord bot cogs

### DIFF
--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -429,7 +429,7 @@ class AI(commands.Cog):
                 title=f"{personality['emoji']} {personality['name']} Responds",
                 description=ai_response,
                 color=personality['color'],
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             
             # Truncate long questions for display

--- a/cogs/autologging.py
+++ b/cogs/autologging.py
@@ -49,7 +49,7 @@ class AutoLogging(commands.Cog):
             
             # Store join data in database
             database.db.update_user_data(member.id, {
-                "guild_join_date": datetime.utcnow().timestamp(),
+                "guild_join_date": datetime.now(datetime.UTC).timestamp(),
                 "guild_id": member.guild.id
             })
             
@@ -65,9 +65,9 @@ class AutoLogging(commands.Cog):
                                 title="🎉 Welcome!",
                                 description=f"{member.mention} joined the server.",
                                 color=discord.Color.green(),
-                                timestamp=datetime.utcnow()
+                                timestamp=datetime.now(datetime.UTC)
                             )
-                            channel_embed.add_field(name="📅 Joined", value=f"<t:{int(datetime.utcnow().timestamp())}:F>", inline=True)
+                            channel_embed.add_field(name="📅 Joined", value=f"<t:{int(datetime.now(datetime.UTC).timestamp())}:F>", inline=True)
                             await welcome_channel.send(embed=channel_embed)
                         except Exception as e:
                             logger.error(f"Error sending simplified welcome message: {e}")
@@ -83,7 +83,7 @@ class AutoLogging(commands.Cog):
                         title="🎉 Welcome to the Server!",
                         description=message_content,
                         color=discord.Color.green(),
-                        timestamp=datetime.utcnow()
+                        timestamp=datetime.now(datetime.UTC)
                     )
                     dm_embed.set_thumbnail(url=member.display_avatar.url)
                     await member.send(embed=dm_embed)
@@ -97,7 +97,7 @@ class AutoLogging(commands.Cog):
                     title="📥 Member Joined",
                     description=f"{member.mention} joined the server",
                     color=discord.Color.green(),
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.now(datetime.UTC)
                 )
                 embed.set_thumbnail(url=member.display_avatar.url)
                 embed.add_field(name="👤 User", value=f"{member} ({member.id})", inline=True)
@@ -125,7 +125,7 @@ class AutoLogging(commands.Cog):
             join_date = user_data.get("guild_join_date")
             days_in_server = 0
             if join_date:
-                days_in_server = int((datetime.utcnow().timestamp() - join_date) / 86400)
+                days_in_server = int((datetime.now(datetime.UTC).timestamp() - join_date) / 86400)
             
             # Leave Message (simplified in channel, DM farewell)
             if settings.get("welcome_enabled"):
@@ -138,9 +138,9 @@ class AutoLogging(commands.Cog):
                                 title="👋 Member Left",
                                 description=f"{member.display_name} left the server.",
                                 color=discord.Color.orange(),
-                                timestamp=datetime.utcnow()
+                                timestamp=datetime.now(datetime.UTC)
                             )
-                            channel_embed.add_field(name="📅 Left", value=f"<t:{int(datetime.utcnow().timestamp())}:F>", inline=True)
+                            channel_embed.add_field(name="📅 Left", value=f"<t:{int(datetime.now(datetime.UTC).timestamp())}:F>", inline=True)
                             await welcome_channel.send(embed=channel_embed)
                         except Exception as e:
                             logger.error(f"Error sending simplified leave message: {e}")
@@ -156,7 +156,7 @@ class AutoLogging(commands.Cog):
                         title="👋 Farewell",
                         description=message_content,
                         color=discord.Color.orange(),
-                        timestamp=datetime.utcnow()
+                        timestamp=datetime.now(datetime.UTC)
                     )
                     await member.send(embed=dm_embed)
                 except Exception:
@@ -169,7 +169,7 @@ class AutoLogging(commands.Cog):
                     title="📤 Member Left",
                     description=f"{member} left the server",
                     color=discord.Color.orange(),
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.now(datetime.UTC)
                 )
                 embed.set_thumbnail(url=member.display_avatar.url)
                 embed.add_field(name="👤 User", value=f"{member} ({member.id})", inline=True)
@@ -205,7 +205,7 @@ class AutoLogging(commands.Cog):
                 "author": message.author,
                 "channel": message.channel,
                 "attachments": [att.url for att in message.attachments],
-                "timestamp": datetime.utcnow()
+                "timestamp": datetime.now(datetime.UTC)
             }
             
             # Keep cache size manageable
@@ -231,7 +231,7 @@ class AutoLogging(commands.Cog):
             embed = discord.Embed(
                 title="🗑️ Message Deleted",
                 color=discord.Color.red(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             
             embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
@@ -270,7 +270,7 @@ class AutoLogging(commands.Cog):
             embed = discord.Embed(
                 title="✏️ Message Edited",
                 color=discord.Color.yellow(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             
             embed.set_author(name=str(before.author), icon_url=before.author.display_avatar.url)
@@ -318,7 +318,7 @@ class AutoLogging(commands.Cog):
                     embed = discord.Embed(
                         title="🎭 Member Roles Updated",
                         color=discord.Color.blue(),
-                        timestamp=datetime.utcnow()
+                        timestamp=datetime.now(datetime.UTC)
                     )
                     embed.set_author(name=str(after), icon_url=after.display_avatar.url)
                     embed.add_field(name="👤 Member", value=f"{after.mention} ({after.id})", inline=True)
@@ -343,7 +343,7 @@ class AutoLogging(commands.Cog):
                 embed = discord.Embed(
                     title="📝 Nickname Changed",
                     color=discord.Color.purple(),
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.now(datetime.UTC)
                 )
                 embed.set_author(name=str(after), icon_url=after.display_avatar.url)
                 embed.add_field(name="👤 Member", value=f"{after.mention} ({after.id})", inline=True)
@@ -373,7 +373,7 @@ class AutoLogging(commands.Cog):
                 title="📺 Channel Created",
                 description=f"New channel: {channel.mention}",
                 color=discord.Color.green(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.add_field(name="📺 Channel", value=f"{channel.name} ({channel.id})", inline=True)
             embed.add_field(name="🗂️ Type", value=channel.type.name.title(), inline=True)
@@ -402,7 +402,7 @@ class AutoLogging(commands.Cog):
                 title="🗑️ Channel Deleted",
                 description=f"Deleted channel: **{channel.name}**",
                 color=discord.Color.red(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.add_field(name="📺 Channel", value=f"{channel.name} ({channel.id})", inline=True)
             embed.add_field(name="🗂️ Type", value=channel.type.name.title(), inline=True)
@@ -436,7 +436,7 @@ class AutoLogging(commands.Cog):
                 embed = discord.Embed(
                     title="🔊 Voice Channel Joined",
                     color=discord.Color.green(),
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.now(datetime.UTC)
                 )
                 embed.set_author(name=str(member), icon_url=member.display_avatar.url)
                 embed.add_field(name="👤 Member", value=member.mention, inline=True)
@@ -447,7 +447,7 @@ class AutoLogging(commands.Cog):
                 embed = discord.Embed(
                     title="🔇 Voice Channel Left",
                     color=discord.Color.orange(),
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.now(datetime.UTC)
                 )
                 embed.set_author(name=str(member), icon_url=member.display_avatar.url)
                 embed.add_field(name="👤 Member", value=member.mention, inline=True)
@@ -458,7 +458,7 @@ class AutoLogging(commands.Cog):
                 embed = discord.Embed(
                     title="🔄 Voice Channel Switched",
                     color=discord.Color.blue(),
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.now(datetime.UTC)
                 )
                 embed.set_author(name=str(member), icon_url=member.display_avatar.url)
                 embed.add_field(name="👤 Member", value=member.mention, inline=True)
@@ -488,7 +488,7 @@ class AutoLogging(commands.Cog):
             embed = discord.Embed(
                 title="🔨 Member Banned",
                 color=discord.Color.dark_red(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.set_author(name=str(user), icon_url=user.display_avatar.url)
             embed.add_field(name="👤 User", value=f"{user} ({user.id})", inline=True)
@@ -528,7 +528,7 @@ class AutoLogging(commands.Cog):
             embed = discord.Embed(
                 title="🔓 Member Unbanned",
                 color=discord.Color.green(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.set_author(name=str(user), icon_url=user.display_avatar.url)
             embed.add_field(name="👤 User", value=f"{user} ({user.id})", inline=True)

--- a/cogs/core_user_system.py
+++ b/cogs/core_user_system.py
@@ -58,7 +58,7 @@ class EmbedBuilder:
         if footer_text:
             embed.set_footer(text=footer_text, icon_url=footer_icon)
         elif timestamp:
-            embed.timestamp = datetime.utcnow()
+            embed.timestamp = datetime.now(datetime.UTC)
             
         return embed
     
@@ -302,11 +302,11 @@ class ProfileView(discord.ui.View):
                        inline=True)
         
         # Account info
-        created_at = user_data.get("created_at", datetime.utcnow())
+        created_at = user_data.get("created_at", datetime.now(datetime.UTC))
         if isinstance(created_at, str):
             created_at = datetime.fromisoformat(created_at)
         
-        days_active = (datetime.utcnow() - created_at).days
+        days_active = (datetime.now(datetime.UTC) - created_at).days
         embed.add_field(name="📅 Account", 
                        value=f"**Days Active:** {days_active}\n**Member Since:** <t:{int(created_at.timestamp())}:R>", 
                        inline=True)
@@ -441,7 +441,7 @@ class CoreUserSystem(commands.Cog):
         embed.add_field(name="🎮 Games & Fun", value="\n".join(features[4:]), inline=True)
         
         # System status
-        uptime = datetime.utcnow() - self.bot.start_time if hasattr(self.bot, 'start_time') else None
+        uptime = datetime.now(datetime.UTC) - self.bot.start_time if hasattr(self.bot, 'start_time') else None
         if uptime:
             embed.add_field(name="⏱️ Uptime", value=f"`{uptime.days}d {uptime.seconds//3600}h {(uptime.seconds%3600)//60}m`", inline=True)
         
@@ -540,15 +540,15 @@ class CoreUserSystem(commands.Cog):
                        inline=True)
         
         # Account age and activity
-        created_at = user_data.get("created_at", datetime.utcnow())
+        created_at = user_data.get("created_at", datetime.now(datetime.UTC))
         if isinstance(created_at, str):
             created_at = datetime.fromisoformat(created_at)
         
-        last_seen = user_data.get("last_seen", datetime.utcnow())
+        last_seen = user_data.get("last_seen", datetime.now(datetime.UTC))
         if isinstance(last_seen, str):
             last_seen = datetime.fromisoformat(last_seen)
         
-        days_active = (datetime.utcnow() - created_at).days
+        days_active = (datetime.now(datetime.UTC) - created_at).days
         
         embed.add_field(name="📅 Account Info", 
                        value=f"**Member Since:** <t:{int(created_at.timestamp())}:R>\n**Days Active:** `{days_active}`\n**Last Seen:** <t:{int(last_seen.timestamp())}:R>", 
@@ -675,7 +675,7 @@ class CoreUserSystem(commands.Cog):
         
         # Creation date and age
         created_at = guild.created_at
-        days_old = (datetime.utcnow() - created_at.replace(tzinfo=None)).days
+        days_old = (datetime.now(datetime.UTC) - created_at.replace(tzinfo=None)).days
         
         embed.add_field(name="📅 Created", value=f"<t:{int(created_at.timestamp())}:F>", inline=True)
         embed.add_field(name="🗓️ Age", value=f"`{days_old:,}` days old", inline=True)
@@ -744,7 +744,7 @@ class CoreUserSystem(commands.Cog):
             
             database.db.update_user_data(message.author.id, {
                 "stats": stats,
-                "last_seen": datetime.utcnow()
+                "last_seen": datetime.now(datetime.UTC)
             })
         except Exception as e:
             pass  # Non-critical error

--- a/cogs/enhanced_pet_system.py
+++ b/cogs/enhanced_pet_system.py
@@ -148,7 +148,7 @@ class PetBattleView(discord.ui.View):
         # Create battle result embed
         embed = discord.Embed(
             title="⚔️ Pet Battle Results!",
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         if winner_pet:
@@ -324,7 +324,7 @@ class PetAdoptionView(discord.ui.View):
                     "battles_total": 0,
                     "breeding_available": True,
                     "achievements": [],
-                    "adopted_date": datetime.utcnow().timestamp()
+                    "adopted_date": datetime.now(datetime.UTC).timestamp()
                 }
                 
                 # Add pet to user's collection
@@ -337,7 +337,7 @@ class PetAdoptionView(discord.ui.View):
                     title="🎉 Pet Adopted Successfully!",
                     description=f"**{interaction.user.display_name}** adopted a {rarity} **{species}**!",
                     color=discord.Color.green(),
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.now(datetime.UTC)
                 )
                 embed.set_thumbnail(url=interaction.user.display_avatar.url)
                 embed.add_field(name="🐾 Name", value=name, inline=True)
@@ -404,7 +404,7 @@ class EnhancedPetSystem(commands.Cog):
             title="🏠 Pet Adoption Center",
             description="Welcome to the adoption center! Choose a pet to become your companion.",
             color=discord.Color.blue(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         embed.add_field(
@@ -480,7 +480,7 @@ class EnhancedPetSystem(commands.Cog):
                     title=f"🐾 {interaction.user.display_name}'s Pets",
                     description="Choose a pet name with `/pet status <pet_name>` or use the dropdown below in future updates.",
                     color=discord.Color.blurple(),
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.now(datetime.UTC)
                 )
                 embed.set_thumbnail(url=interaction.user.display_avatar.url)
                 pet_lines = []
@@ -501,7 +501,7 @@ class EnhancedPetSystem(commands.Cog):
             title=f"{pet['emoji']} {pet['name']}'s Profile",
             description=f"**{pet['species']}** • Level {pet.get('level', 1)} • {pet['rarity'].title()}",
             color=discord.Color.blue(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.set_thumbnail(url=interaction.user.display_avatar.url)
         
@@ -627,7 +627,7 @@ class EnhancedPetSystem(commands.Cog):
             title=f"{pet['emoji']} {activity.title()} Complete!",
             description=f"You spent time {activity}ing with **{pet['name']}**!",
             color=discord.Color.green(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         embed.add_field(name="💰 Cost", value=f"{cost} coins", inline=True)
@@ -690,7 +690,7 @@ class EnhancedPetSystem(commands.Cog):
             title="⚔️ Pet Battle Challenge!",
             description=f"**{interaction.user.display_name}** challenges **{opponent.display_name}** to a pet battle!",
             color=discord.Color.red(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         embed.add_field(
@@ -803,7 +803,7 @@ class EnhancedPetSystem(commands.Cog):
             title="✨ Evolution Complete!",
             description=f"**{selected_pet['name']}** has evolved!",
             color=discord.Color.gold(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         embed.add_field(

--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -31,7 +31,7 @@ class ErrorHandler(commands.Cog):
         """Handle traditional command errors"""
         self.error_stats["command_errors"] += 1
         self.error_stats["total_errors"] += 1
-        self.error_stats["last_error_time"] = datetime.utcnow()
+        self.error_stats["last_error_time"] = datetime.now(datetime.UTC)
         
         # Ignore certain errors
         ignored_errors = (commands.CommandNotFound, commands.DisabledCommand)
@@ -111,7 +111,7 @@ class ErrorHandler(commands.Cog):
         """Handle slash command errors"""
         self.error_stats["app_command_errors"] += 1
         self.error_stats["total_errors"] += 1
-        self.error_stats["last_error_time"] = datetime.utcnow()
+        self.error_stats["last_error_time"] = datetime.now(datetime.UTC)
         
         # Handle specific errors
         if isinstance(error, app_commands.MissingPermissions):
@@ -185,7 +185,7 @@ class ErrorHandler(commands.Cog):
             embed = discord.Embed(
                 title="🚨 Unexpected Error Occurred",
                 color=discord.Color.dark_red(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             
             # Add context information
@@ -245,7 +245,7 @@ class ErrorHandler(commands.Cog):
         """Handle errors in event listeners"""
         self.error_stats["listener_errors"] += 1
         self.error_stats["total_errors"] += 1
-        self.error_stats["last_error_time"] = datetime.utcnow()
+        self.error_stats["last_error_time"] = datetime.now(datetime.UTC)
         
         error_info = sys.exc_info()
         if error_info[0] is not None:
@@ -261,7 +261,7 @@ class ErrorHandler(commands.Cog):
                             title=f"🚨 Event Error: {event}",
                             description=f"```python\n{error_msg[:1500]}```",
                             color=discord.Color.dark_red(),
-                            timestamp=datetime.utcnow()
+                            timestamp=datetime.now(datetime.UTC)
                         )
                         await error_channel.send(embed=embed)
                 except Exception as log_error:
@@ -292,7 +292,7 @@ class ErrorHandler(commands.Cog):
             embed = discord.Embed(
                 title="📊 Bot Error Statistics",
                 color=discord.Color.blue(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             
             embed.add_field(name="Total Errors", value=f"`{self.error_stats['total_errors']}`", inline=True)
@@ -311,7 +311,7 @@ class ErrorHandler(commands.Cog):
             
             # Bot uptime
             if hasattr(self.bot, 'start_time'):
-                uptime = datetime.utcnow() - self.bot.start_time
+                uptime = datetime.now(datetime.UTC) - self.bot.start_time
                 embed.add_field(name="Bot Uptime", value=f"`{uptime.days}d {uptime.seconds//3600}h {(uptime.seconds%3600)//60}m`", inline=True)
             
             embed.set_footer(text="Error statistics are reset when the bot restarts")

--- a/cogs/fixed_jobsystem.py
+++ b/cogs/fixed_jobsystem.py
@@ -155,7 +155,7 @@ class JobApplicationView(discord.ui.View):
             title="🎉 Congratulations!",
             description=f"**{interaction.user.display_name}** has been hired!",
             color=discord.Color.green(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.add_field(name="🏢 Career Path", value=f"{path_data['emoji']} {path_data['name']}", inline=True)
         embed.add_field(name="💼 Position", value=starting_job["title"], inline=True)
@@ -214,7 +214,7 @@ class JobSystem(commands.Cog):
             title=f"{path_data['emoji']} Career Profile",
             description=f"**{interaction.user.display_name}** - {current_job['title']}",
             color=discord.Color.blue(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.set_thumbnail(url=interaction.user.display_avatar.url)
         
@@ -355,7 +355,7 @@ class JobSystem(commands.Cog):
             title=f"💼 Work Complete!",
             description=f"**{interaction.user.display_name}** {activity} as a **{current_job['title']}**",
             color=discord.Color.green(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.set_thumbnail(url=interaction.user.display_avatar.url)
         
@@ -467,7 +467,7 @@ class JobSystem(commands.Cog):
             title="🎉 PROMOTION!",
             description=f"**{interaction.user.display_name}** has been promoted!",
             color=discord.Color.gold(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.set_thumbnail(url=interaction.user.display_avatar.url)
         embed.add_field(name="🆙 New Position", value=next_job["title"], inline=True)
@@ -511,7 +511,7 @@ class JobSystem(commands.Cog):
                     title="📤 Resignation Accepted",
                     description=f"**{interaction.user.display_name}** has resigned from their position.",
                     color=discord.Color.orange(),
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.now(datetime.UTC)
                 )
                 embed.add_field(name="📋 Former Position", value=current_title, inline=True)
                 embed.add_field(name="⏱️ Employment Duration", value=f"{days_employed} days", inline=True)
@@ -558,7 +558,7 @@ class JobSystem(commands.Cog):
             title="📊 Employment Overview",
             description="Server-wide employment statistics",
             color=discord.Color.green(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         if career_path:

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -127,7 +127,7 @@ class Fun(commands.Cog):
             else:
                 result = "Opponent wins!"
                 color = discord.Color.red()
-            embed = discord.Embed(title="🪨📄✂️ RPS Duel Result", color=color, timestamp=datetime.utcnow())
+            embed = discord.Embed(title="🪨📄✂️ RPS Duel Result", color=color, timestamp=datetime.now(datetime.UTC))
             embed.add_field(name="Challenger", value=c_choice.title(), inline=True)
             embed.add_field(name="Opponent", value=o_choice.title(), inline=True)
             embed.set_footer(text=result)
@@ -188,7 +188,7 @@ class Fun(commands.Cog):
             return
         ends_at = asyncio.get_event_loop().time() + duration_minutes * 60
         view = Fun.GiveawayView(interaction.user.id, ends_at)
-        embed = discord.Embed(title="🎉 Giveaway!", description=f"Prize: **{prize}**\nEnds: <t:{int(datetime.utcnow().timestamp() + duration_minutes*60)}:R>", color=discord.Color.gold())
+        embed = discord.Embed(title="🎉 Giveaway!", description=f"Prize: **{prize}**\nEnds: <t:{int(datetime.now(datetime.UTC).timestamp() + duration_minutes*60)}:R>", color=discord.Color.gold())
         await interaction.response.send_message(embed=embed, view=view)
         view.message = await interaction.original_response()
         async def conclude():
@@ -202,11 +202,6 @@ class Fun(commands.Cog):
             result = discord.Embed(title="🎉 Giveaway Winner!", description=f"Winner: <@{winner_id}>\nPrize: **{prize}**", color=discord.Color.green())
             await view.message.edit(embed=result, view=None)
         self.bot.loop.create_task(conclude())
-        
-    @app_commands.command(name="slots", description="Play a slot machine.")
-    async def slots(self, interaction: discord.Interaction):
-        # Placeholder for Slots command
-        await interaction.response.send_message("This command is under development!")
         
     @app_commands.command(name="trivia", description="Start a trivia game.")
     async def trivia(self, interaction: discord.Interaction):

--- a/cogs/quicksetup.py
+++ b/cogs/quicksetup.py
@@ -319,7 +319,7 @@ class SetupView(discord.ui.View):
             title="🔧 Current Bot Configuration",
             description=f"Configuration for **{interaction.guild.name}**",
             color=discord.Color.blue(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         # Logging Configuration
@@ -395,7 +395,7 @@ class Settings(commands.Cog):
             title="🚀 BlackOps Bot - Complete Setup Wizard",
             description="Welcome to the comprehensive bot configuration system!\n\nClick the buttons below to set up different systems:",
             color=discord.Color.gold(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         embed.add_field(
@@ -459,7 +459,7 @@ class Settings(commands.Cog):
             title="⭐ Starboard Configured!",
             description=f"Messages with **{threshold}** `{emoji}` reactions will be sent to {channel.mention}",
             color=discord.Color.gold(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.set_thumbnail(url=interaction.guild.icon.url)
         
@@ -475,7 +475,7 @@ class Settings(commands.Cog):
             title="⚙️ Server Configuration Overview",
             description=f"Current settings for **{interaction.guild.name}**",
             color=discord.Color.teal(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         # System Status Overview
@@ -585,7 +585,7 @@ class Settings(commands.Cog):
                             "starboard_message_id": starboard_msg.id,
                             "original_channel_id": channel.id,
                             "reaction_count": reaction.count,
-                            "created_at": datetime.utcnow().timestamp()
+                            "created_at": datetime.now(datetime.UTC).timestamp()
                         }
                         
                         database.db.update_guild_data(payload.guild_id, {

--- a/cogs/tickets.py
+++ b/cogs/tickets.py
@@ -131,7 +131,7 @@ class TicketControlView(discord.ui.View):
                     title="🎫 Ticket Transcript",
                     description=f"Your ticket **{interaction.channel.name}** has been closed.",
                     color=discord.Color.blue(),
-                    timestamp=datetime.utcnow()
+                    timestamp=datetime.now(datetime.UTC)
                 )
                 embed.add_field(name="Channel", value=interaction.channel.name, inline=True)
                 embed.add_field(name="Closed by", value=interaction.user.mention, inline=True)
@@ -173,7 +173,7 @@ class TicketControlView(discord.ui.View):
         transcript = f"TICKET TRANSCRIPT\n"
         transcript += f"Channel: {channel.name}\n"
         transcript += f"Created: {channel.created_at.strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
-        transcript += f"Generated: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
+        transcript += f"Generated: {datetime.now(datetime.UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
         transcript += "=" * 50 + "\n\n"
         
         try:
@@ -285,7 +285,7 @@ class TicketCreateView(discord.ui.View):
             title=f"{info['emoji']} Support Ticket Created",
             description=f"**Type:** {ticket_type.title()}\n**User:** {member.mention}",
             color=info['color'],
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         embed.add_field(
@@ -322,7 +322,7 @@ class Tickets(commands.Cog):
             title="🎫 Support Ticket System",
             description="Need help? Create a support ticket below!\n\nSelect the type of support you need and our team will assist you.",
             color=discord.Color.blue(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         embed.add_field(
@@ -399,7 +399,7 @@ class Tickets(commands.Cog):
         embed = discord.Embed(
             title="📊 Ticket System Statistics",
             color=discord.Color.green(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         embed.add_field(name="🎫 Total Open Tickets", value=f"`{len(ticket_channels)}`", inline=True)

--- a/cogs/unified_economy.py
+++ b/cogs/unified_economy.py
@@ -160,7 +160,7 @@ class EconomyView(discord.ui.View):
         embed = discord.Embed(
             title="💰 Wallet Overview",
             color=discord.Color.gold(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.add_field(name="💵 Cash", value=f"`{coins:,}` coins", inline=True)
         embed.add_field(name="🏦 Bank", value=f"`{bank:,}` coins", inline=True)
@@ -200,7 +200,7 @@ class UnifiedEconomy(commands.Cog):
         embed = discord.Embed(
             title=f"💰 {target_user.display_name}'s Financial Portfolio",
             color=discord.Color.gold(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.set_thumbnail(url=target_user.display_avatar.url)
         
@@ -250,7 +250,7 @@ class UnifiedEconomy(commands.Cog):
                 title="🎉 Daily Rewards Claimed!",
                 description=f"**{interaction.user.display_name}** claimed their daily bonus!",
                 color=discord.Color.green(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             
             embed.add_field(name="💰 Coins Earned", value=f"`{result['coins_earned']:,}` coins", inline=True)
@@ -290,7 +290,7 @@ class UnifiedEconomy(commands.Cog):
             title="🛒 Premium Items Shop",
             description="Purchase temporary boosts and premium items with your coins!",
             color=discord.Color.blue(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         # Filter items by category if specified
@@ -368,7 +368,7 @@ class UnifiedEconomy(commands.Cog):
             title="🎉 Purchase Successful!",
             description=f"**{interaction.user.display_name}** purchased {quantity}x **{item_details['emoji']} {item.title().replace('_', ' ')}** {tier_emoji}",
             color=discord.Color.green(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.add_field(name="💰 Total Cost", value=f"`{total_cost:,}` coins", inline=True)
         embed.add_field(name="⏰ Duration", value=f"`{int(total_duration / 3600)}` hours", inline=True)
@@ -447,7 +447,7 @@ class UnifiedEconomy(commands.Cog):
                 title=f"🪙 {actual_outcome.upper()} - You Win!",
                 description=f"**{interaction.user.display_name}** won `{final_winnings:,}` coins!",
                 color=discord.Color.green(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.add_field(name="💰 Winnings", value=f"`{final_winnings:,}` coins", inline=True)
             embed.add_field(name="💵 New Balance", value=f"`{new_balance:,}` coins", inline=True)
@@ -462,7 +462,7 @@ class UnifiedEconomy(commands.Cog):
                 title=f"🪙 {actual_outcome.upper()} - You Lose!",
                 description=f"**{interaction.user.display_name}** lost `{amount:,}` coins!",
                 color=discord.Color.red(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.add_field(name="💸 Lost", value=f"`{amount:,}` coins", inline=True)
             embed.add_field(name="💵 New Balance", value=f"`{new_balance:,}` coins", inline=True)
@@ -550,7 +550,7 @@ class UnifiedEconomy(commands.Cog):
             embed = discord.Embed(
                 title="🎰 JACKPOT! 🎰",
                 color=discord.Color.gold(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.add_field(name="🎯 Result", value=f"```{slot_display}```", inline=False)
             embed.add_field(name="💰 Total Winnings", value=f"`{winnings:,}` coins", inline=True)
@@ -561,7 +561,7 @@ class UnifiedEconomy(commands.Cog):
             embed = discord.Embed(
                 title="🎰 Better Luck Next Time!",
                 color=discord.Color.red(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.add_field(name="🎯 Result", value=f"```{slot_display}```", inline=False)
             embed.add_field(name="💸 Lost", value=f"`{bet:,}` coins", inline=True)
@@ -588,7 +588,7 @@ class UnifiedEconomy(commands.Cog):
         embed = discord.Embed(
             title=f"🏦 {interaction.user.display_name}'s Banking Dashboard",
             color=discord.Color.blue(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.set_thumbnail(url=interaction.user.display_avatar.url)
         
@@ -672,7 +672,7 @@ class UnifiedEconomy(commands.Cog):
                 title="📈 Compound Interest Claimed!",
                 description=f"**{interaction.user.display_name}** earned interest on their savings!",
                 color=discord.Color.green(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.add_field(name="💰 Interest Earned", value=f"`{interest_earned:,}` coins", inline=True)
             embed.add_field(name="🏦 New Balance", value=f"`{new_bank_balance:,}` coins", inline=True)
@@ -707,7 +707,7 @@ class UnifiedEconomy(commands.Cog):
                 title="🏦 Deposit Successful",
                 description=f"**{interaction.user.display_name}** deposited money into savings!",
                 color=discord.Color.green(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.add_field(name="💰 Deposited", value=f"`{amount:,}` coins", inline=True)
             embed.add_field(name="🏦 New Balance", value=f"`{user_data['bank'] + amount:,}` coins", inline=True)
@@ -736,7 +736,7 @@ class UnifiedEconomy(commands.Cog):
                 title="💸 Withdrawal Successful",
                 description=f"**{interaction.user.display_name}** withdrew money from savings!",
                 color=discord.Color.blue(),
-                timestamp=datetime.utcnow()
+                timestamp=datetime.now(datetime.UTC)
             )
             embed.add_field(name="💰 Withdrawn", value=f"`{amount:,}` coins", inline=True)
             embed.add_field(name="🏦 Remaining", value=f"`{user_data['bank'] - amount:,}` coins", inline=True)
@@ -801,7 +801,7 @@ class UnifiedEconomy(commands.Cog):
             title=f"{investment['emoji']} Investment Made!",
             description=f"**{interaction.user.display_name}** invested in {investment['name']}",
             color=discord.Color.blue(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         embed.add_field(name="💰 Invested", value=f"`{amount:,}` coins", inline=True)
         embed.add_field(name="⏰ Matures", value=f"<t:{mature_timestamp}:R>", inline=True)
@@ -843,7 +843,7 @@ class UnifiedEconomy(commands.Cog):
             title="📊 Investment Portfolio",
             description=f"**{interaction.user.display_name}'s** Active Investments",
             color=discord.Color.green(),
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(datetime.UTC)
         )
         
         total_invested = 0

--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ class BlackOpsBot(commands.Bot):
             case_insensitive=True,
             strip_after_prefix=True
         )
-        self.start_time = datetime.utcnow()
+        self.start_time = datetime.now(datetime.UTC)
         self.cogs_loaded = 0
         self.total_cogs = 0
         
@@ -288,10 +288,10 @@ def home():
         "bot_name": bot.user.name if bot.user else "Bot",
         "guilds": len(bot.guilds) if bot.is_ready() else 0,
         "users": len(bot.users) if bot.is_ready() else 0,
-        "uptime": str(datetime.utcnow() - bot.start_time) if hasattr(bot, 'start_time') else "Unknown",
+        "uptime": str(datetime.now(datetime.UTC) - bot.start_time) if hasattr(bot, 'start_time') else "Unknown",
         "latency": round(bot.latency * 1000, 2) if bot.is_ready() else 0,
         "cogs_loaded": f"{bot.cogs_loaded}/{bot.total_cogs}",
-        "timestamp": datetime.utcnow().isoformat()
+        "timestamp": datetime.now(datetime.UTC).isoformat()
     })
 
 @app.route('/health')
@@ -308,14 +308,14 @@ def health():
             "status": "online" if bot.is_ready() else "offline",
             "guilds": len(bot.guilds) if bot.is_ready() else 0,
             "latency": round(bot.latency * 1000, 2) if bot.is_ready() else 0,
-            "uptime_seconds": (datetime.utcnow() - bot.start_time).total_seconds() if hasattr(bot, 'start_time') else 0
+            "uptime_seconds": (datetime.now(datetime.UTC) - bot.start_time).total_seconds() if hasattr(bot, 'start_time') else 0
         },
         "database": db_health,
         "system": {
             "cogs_loaded": f"{bot.cogs_loaded}/{bot.total_cogs}",
             "commands": len(bot.tree.get_commands()) if bot.is_ready() else 0
         },
-        "timestamp": datetime.utcnow().isoformat()
+        "timestamp": datetime.now(datetime.UTC).isoformat()
     })
 
 @app.route('/stats')


### PR DESCRIPTION
Replace deprecated `datetime.utcnow()` with `datetime.now(datetime.UTC)` and resolve a `CommandAlreadyRegistered` error for the `slots` command.

The `unified_economy` cog failed to load due to a `CommandAlreadyRegistered` error because both `cogs/fun.py` and `cogs/unified_economy.py` defined a `slots` command. The placeholder command in `cogs/fun.py` was removed, allowing the fully implemented command in `cogs/unified_economy.py` to function correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-47bee212-1a26-4363-97dc-439eaee7db78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47bee212-1a26-4363-97dc-439eaee7db78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

